### PR TITLE
Fix SIGINT handling

### DIFF
--- a/src/prometheus_launchpad_exporter/__main__.py
+++ b/src/prometheus_launchpad_exporter/__main__.py
@@ -68,20 +68,12 @@ async def main():
     log = structlog.get_logger()
     log.debug("Running in debug mode")
 
-    m = Metrics(log, args.series)
-    await m.start()
-
-    try:
-        await asyncio.Event().wait()
-    finally:
-        await m.stop()
-
-    app = Metrics(log)
-
     loop = asyncio.get_event_loop()
 
+    app = Metrics(log, args.series)
+
     for signal_enum in [SIGINT, SIGTERM]:
-        loop.add_signal_handler(signal_enum, asyncio.ensure_future(app.stop))
+        loop.add_signal_handler(signal_enum, app.stop)
 
     await app.start()
 

--- a/src/prometheus_launchpad_exporter/metrics.py
+++ b/src/prometheus_launchpad_exporter/metrics.py
@@ -85,13 +85,11 @@ class Metrics:
             self._service.start(addr="0.0.0.0", port=8000),
         )
 
-    # XXX: this doesn't work properly yet,
-    # (1) KeyboardInterrupt seems to stop the event loop directly and thus this
-    # is never executed
-    # (2) we would still need to add a lot of event checking inside of
-    # fetch_metrics() to interrupt it
-    async def stop(self):
+    # XXX: this could work better
+    # we still need to add a lot of event checking inside of fetch_metrics() to
+    # interrupt it. It works now but the interrupt doesn't happen until the sync
+    # calls finish
+    def stop(self):
         self.log.info("Stopping prometheus-launchpad-exporter")
         self._stop_thread_event.set()
-        await self._service.stop()
         self._metrics_refresh_timer = None


### PR DESCRIPTION
Somehow we'd ended up with a bunch of duped code, throw that away. Now
interrupting sort of works - but it has to be a non-async method. Just
make it signal the thread to finish on its next go-round.
