### PR TITLE
Moar caches

### DIFF
--- a/src/prometheus_launchpad_exporter/launchpad.py
+++ b/src/prometheus_launchpad_exporter/launchpad.py
@@ -25,11 +25,11 @@ class LP:
     def __init__(self, log, cache_dir=None):
         self.log = log
 
-        self.series_cache = cachetools.LRUCache(maxsize=50)
-        self.packageset_cache = cachetools.TTLCache(maxsize=50, ttl=10 * 60)
-        self.packageset_sources_cache = cachetools.TTLCache(maxsize=50, ttl=60 * 60)
+        self.series_cache = cachetools.LRUCache(maxsize=512)
+        self.packageset_cache = cachetools.TTLCache(maxsize=512, ttl=10 * 60)
+        self.packageset_sources_cache = cachetools.TTLCache(maxsize=512, ttl=60 * 60)
         # 1 minute expiry on the queues, they move fast
-        self.queue_cache = cachetools.TTLCache(maxsize=50, ttl=1 * 60)
+        self.queue_cache = cachetools.TTLCache(maxsize=512, ttl=1 * 60)
 
         self.cache_dir = cache_dir
         if cache_dir is None:


### PR DESCRIPTION
When running for all series, the cache isn't big enough atm, so we end up always hitting LP