### PR TITLE
Fetch build statuses

### DIFF
--- a/src/prometheus_launchpad_exporter/__main__.py
+++ b/src/prometheus_launchpad_exporter/__main__.py
@@ -58,7 +58,15 @@ async def main():
         action="append",
         help="Series to export metrics for",
     )
+    parser.add_argument(
+        "--packageset",
+        action="append",
+        help="Packageset to export metrics for",
+    )
     args = parser.parse_args()
+
+    if args.packageset is None:
+        args.packageset = []
 
     logging.basicConfig(
         format="%(message)s",
@@ -89,7 +97,7 @@ async def main():
 
     loop = asyncio.get_event_loop()
 
-    app = Metrics(log, args.series)
+    app = Metrics(log, args.series, args.packageset)
 
     for signal_enum in [SIGINT, SIGTERM]:
         loop.add_signal_handler(signal_enum, app.stop)

--- a/src/prometheus_launchpad_exporter/launchpad.py
+++ b/src/prometheus_launchpad_exporter/launchpad.py
@@ -30,6 +30,8 @@ class LP:
         self.packageset_sources_cache = cachetools.TTLCache(maxsize=512, ttl=60 * 60)
         # 1 minute expiry on the queues, they move fast
         self.queue_cache = cachetools.TTLCache(maxsize=512, ttl=1 * 60)
+        self.archive_cache = cachetools.LRUCache(maxsize=1)
+        self.distribution_cache = cachetools.LRUCache(maxsize=1)
 
         self.cache_dir = cache_dir
         if cache_dir is None:
@@ -44,10 +46,11 @@ class LP:
         )
 
     @property
-    def all_current_series(self):
+    def all_current_series_names(self):
+        ubuntu = self.get_distribution("ubuntu")
         return [
-            self.get_series(series.name)
-            for series in self.lp.distributions["ubuntu"].series
+            series.name
+            for series in ubuntu.series
             if series.status
             in (
                 "Active Development",
@@ -58,18 +61,30 @@ class LP:
             )
         ]
 
+    @cachetools.cachedmethod(
+        lambda self: self.distribution_cache,
+    )
+    def get_distribution(self, distribution_name):
+        self.log.debug(
+            "getting distribution from LP", distribution_name=distribution_name
+        )
+        return self.lp.distributions[distribution_name]
+
     @cachetools.cachedmethod(lambda self: self.series_cache)
     def get_series(self, name):
         self.log.debug("getting series from LP", name=name)
-        return self.lp.distributions["ubuntu"].getSeries(name_or_version=name)
+        ubuntu = self.get_distribution("ubuntu")
+        return ubuntu.getSeries(name_or_version=name)
 
     @cachetools.cachedmethod(
         lambda self: self.packageset_cache,
-        key=lambda _, series: series.name,
     )
-    def get_packagesets(self, series):
-        self.log.debug("getting packagesets from LP", series=series.name)
-        return self.lp.packagesets.getBySeries(distroseries=series)
+    def get_all_packagesets_for_series(self, series):
+        self.log.debug("getting packagesets from LP", series=series)
+        return self.lp.packagesets.getBySeries(distroseries=self.get_series(series))
+
+    def get_packagesets_by_name(self, series, name):
+        return self.lp.packagesets.getByName(distroseries=series, name=name)
 
     @cachetools.cachedmethod(
         lambda self: self.packageset_sources_cache,
@@ -77,7 +92,11 @@ class LP:
     )
     def get_packageset_sources(self, packageset):
         self.log.debug("getting packageset sources from LP", packageset=packageset.name)
-        return packageset.getSourcesIncluded()
+        s = packageset.getSourcesIncluded()
+        self.log.debug(
+            "done getting packageset sources from LP", packageset=packageset.name
+        )
+        return s
 
     @cachetools.cachedmethod(
         lambda self: self.queue_cache,
@@ -89,6 +108,33 @@ class LP:
         )
         return series.getPackageUploads(status=status, pocket=pocket)
 
+    @cachetools.cachedmethod(
+        lambda self: self.archive_cache,
+        key=lambda _, distribution: distribution.name,
+    )
+    def main_archive(self, distribution):
+        self.log.debug("getting main archive from LP", distribution=distribution.name)
+        return distribution.main_archive
+
+    def get_published_sources(self, pocket, source_name, series, created_since_date):
+        self.log.debug(
+            "getting published sources from LP",
+            pocket=pocket,
+            source_name=source_name,
+            series=series.name,
+            created_since_date=created_since_date,
+        )
+        ubuntu = self.get_distribution("ubuntu")
+        ubuntu_archive = self.main_archive(ubuntu)
+        return ubuntu_archive.getPublishedSources(
+            exact_match=True,
+            pocket=pocket,
+            source_name=source_name,
+            distro_series=series,
+            created_since_date=created_since_date,
+            order_by_date=True,
+        )
+
     def login(self):
         self.lp = Launchpad.login_anonymously(
             "prometheus-launchpad-exporter",
@@ -96,3 +142,14 @@ class LP:
             self.cache_dir,
             version="devel",
         )
+
+    @classmethod
+    def get_lp(cls, local, log):
+        """If this TLS has a launchpad instance, return it, otherwise create a
+        new one"""
+        if not hasattr(local, "lp"):
+            log.debug("creating new LP instance")
+            local.lp = cls(log)
+        else:
+            log.debug("reusing existing LP instance")
+        return local.lp

--- a/src/prometheus_launchpad_exporter/ubuntu.py
+++ b/src/prometheus_launchpad_exporter/ubuntu.py
@@ -15,54 +15,244 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import concurrent.futures
+import threading
 from collections import defaultdict
 
 from .launchpad import LP
 
 
+class SourcePackage:
+    """An upload of a source package to a series"""
+
+    def __init__(self, log, name, series_name):
+        self._local = threading.local()
+
+        self.log = log.bind(source=name, series=series_name)
+
+        self._name = name
+        self._series_name = series_name
+
+        self._last_time_checked = {}
+        self._build_status = defaultdict(lambda: defaultdict(str))
+
+    @property
+    def _lp(self):
+        return LP.get_lp(self._local, self.log)
+
+    @property
+    def name(self):
+        return self._name
+
+    def _any_builds_not_successful(self, pocket):
+        return any(
+            state != "Successfully built"
+            for _, state in self._build_status[pocket].values()
+        )
+
+    def get_failed_builds(self):
+        return {
+            pocket: {
+                arch: (version, state)
+                for arch, (version, state) in builds.items()
+                if state == "Failed to build"
+            }
+            for pocket, builds in self._build_status.items()
+        }
+
+    def _fetch_latest_build_status_pocket(self, pocket):
+        log = self.log.bind(pocket=pocket)
+        series = self._lp.get_series(self._series_name)
+        try:
+            latest_spph = self._lp.get_published_sources(
+                pocket,
+                self._name,
+                series,
+                self._last_time_checked.get(pocket, None),
+            )[0]
+        except IndexError:
+            log.debug("No published sources found")
+            return
+
+        # If we've already seen this one, and all of the builds were successful,
+        # we're done. Otherwise, it might have succeeded since we last checked,
+        if latest_spph.date_created == self._last_time_checked.get(
+            pocket, None
+        ) and not self._any_builds_not_successful(pocket):
+            log.debug("all builds successful, skipping")
+            return
+
+        self._last_time_checked[pocket] = latest_spph.date_created
+
+        build_records = latest_spph.getBuilds()
+
+        # if this package was built in this series (wasn't copied forward), then
+        # there will be build records
+        # (https://bugs.launchpad.net/launchpad/+bug/783613)...
+        if len(build_records) > 0:
+            log.debug("found build records", count=len(build_records))
+            for record in build_records:
+                arch = record.arch_tag
+                state = record.buildstate
+                log.debug(
+                    "got build status",
+                    arch=arch,
+                    version=latest_spph.source_package_version,
+                    state=state,
+                )
+                self._build_status[pocket][arch] = (
+                    latest_spph.source_package_version,
+                    state,
+                )
+            return
+
+        # ... if it wasn't then there won't be: the way is to go through binary
+        # publications to find the build
+        bpphs = latest_spph.getPublishedBinaries()
+
+        seen_arches = set()
+
+        log.debug("no build records, looking through bpphs")
+
+        for bpph in bpphs:
+            build = bpph.build
+            arch = build.arch_tag
+
+            if arch in seen_arches:
+                continue
+
+            state = build.buildstate
+
+            seen_arches.add(arch)
+
+            log.debug(
+                "got build status",
+                arch=arch,
+                version=latest_spph.source_package_version,
+                state=state,
+            )
+            self._build_status[pocket][arch] = (
+                latest_spph.source_package_version,
+                state,
+            )
+            if state != "Successfully built":
+                log.info(
+                    "build not successful",
+                    arch=arch,
+                    version=latest_spph.source_package_version,
+                    state=state,
+                )
+
+    def fetch_latest_build_status(self):
+        for pocket in ("Backports", "Proposed", "Release", "Security", "Updates"):
+            self._fetch_latest_build_status_pocket(pocket)
+
+        return self._build_status
+
+    @property
+    def has_any_builds(self):
+        return len(self._build_status) > 0
+
+
 class UbuntuMetrics:
     def __init__(self, log, series):
+        self._local = threading.local()
+
         self.log = log
 
         self._series = series
 
-        self._lp = LP(log)
-
         self._series_queue_count_map = defaultdict(
             lambda: defaultdict(lambda: defaultdict(int))
         )
-        self._series_packageset_source_map = defaultdict(lambda: defaultdict(list))
-        self._source_packageset_map = defaultdict(set)
+        self._series_packageset_source_map = defaultdict(lambda: defaultdict(set))
+        self._series_source_map = defaultdict(dict)
+
+        self._all_lps = []
+
+    @property
+    def _lp(self):
+        return LP.get_lp(self._local, self.log)
 
     def series_to_consider(self):
-        if self._series:
-            return [self._lp.get_series(s) for s in self._series]
+        return self._series if self._series else self._lp.all_current_series_names
 
-        return self._lp.all_current_series
+    def fetch_packageset_for_series(
+        self,
+        packageset_name,
+        series_name,
+        series_source_map,
+        series_packageset_source_map,
+        lock,
+    ):
+        log = self.log.bind(series=series_name, packageset=packageset_name)
+        series = self._lp.get_series(series_name)
+        packageset = self._lp.get_packagesets_by_name(series, packageset_name)
+        sources = self._lp.get_packageset_sources(packageset)
 
-    def populate_packageset_maps(self):
-        for series in self.series_to_consider():
-            self.log.info("fetching packagesets", series=series.name)
-            for packageset in self._lp.get_packagesets(series):
-                self.log.debug(
-                    "got packageset", packageset=packageset.name, series=series.name
-                )
-                sources = self._lp.get_packageset_sources(packageset)
-                for source in sources:
-                    self._source_packageset_map[source].add(packageset.name)
-                    self._series_packageset_source_map[series.name][
-                        packageset.name
-                    ].append(source)
+        log.info("processing packageset", n_sources=len(sources))
+        for source in sources:
+            with lock:
+                sp = self._series_source_map[series_name].get(source)
+                if sp is None:
+                    sp = SourcePackage(self.log, source, series_name)
+                    series_source_map[series_name][source] = sp
+                series_packageset_source_map[series_name][packageset_name].add(sp)
+
+    def populate_packageset_maps(self, packagesets):
+        lock = threading.Lock()
+
+        series_source_map = defaultdict(dict)
+        series_packageset_source_map = defaultdict(lambda: defaultdict(set))
+        for series_name in self.series_to_consider():
+            self.log.info("fetching packagesets", series=series_name)
+
+            if packagesets == []:
+                packagesets = [
+                    packageset.name
+                    for packageset in self._lp.get_all_packagesets_for_series(
+                        series_name
+                    )
+                ]
+
+            self.log.info(
+                "got packagesets",
+                series=series_name,
+                packagesets=" ".join(packagesets),
+            )
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+                for _ in executor.map(
+                    lambda packageset_name: self.fetch_packageset_for_series(
+                        packageset_name,
+                        series_name,
+                        series_source_map,
+                        series_packageset_source_map,
+                        lock,
+                    ),
+                    packagesets,
+                ):
+                    pass
+
+        self._series_source_map = series_source_map
+        self._series_packageset_source_map = series_packageset_source_map
 
         self.log.info("done fetching packagesets")
+        for series_name in self._series_source_map:
+            self.log.debug(
+                "series packages",
+                series=series_name,
+                n_packages=len(self._series_source_map[series_name]),
+            )
 
-        return self._source_packageset_map
+        return self._series_source_map
 
     def fetch_queues(self):
         # series -> queue -> n_packages
         ret = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
-        for series in self.series_to_consider():
-            self.log.info("fetching queues", series=series.name)
+        for series_name in self.series_to_consider():
+            series = self._lp.get_series(series_name)
+            self.log.info("fetching queues", series=series_name)
             for status in ("New", "Unapproved"):
                 for pocket in (
                     "Release",
@@ -74,25 +264,46 @@ class UbuntuMetrics:
                     queue = self._lp.get_queue(series, status, pocket)
                     self.log.debug(
                         "got queue",
-                        series=series.name,
+                        series=series_name,
                         status=status,
                         pocket=pocket,
                         n_queue_items=len(queue),
                     )
-                    ret[series.name][pocket][status] = len(queue)
+                    ret[series_name][pocket][status] = len(queue)
+            self.log.info("done fetching queues", series=series_name)
 
         self._series_queue_count_map = ret
 
-    def get_all_series(self):
-        return self._lp.all_current_series
+    def fetch_build_statuses(self, series_name):
+        self.log.info("fetching build statuses", series=series_name)
+        all_sources = [
+            source
+            for _, sources in self._series_packageset_source_map[series_name].items()
+            for source in sources
+        ]
 
-    @property
-    def source_packageset_map(self):
-        return self._source_packageset_map
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+            for result in executor.map(
+                lambda s: s.fetch_latest_build_status(), all_sources
+            ):
+                pass
+
+        self.log.info("done fetching build statuses", series=series_name)
 
     @property
     def series_packageset_source_map(self):
-        return self._series_packageset_source_map
+        """series -> packageset -> source_package.
+        Only returns sources that are in the series. Packagesets can contain
+        sources that are not in the series."""
+        return {
+            series: {
+                packageset: [source for source in sources if source.has_any_builds]
+                for packageset, sources in self._series_packageset_source_map[
+                    series
+                ].items()
+            }
+            for series in self._series_packageset_source_map
+        }
 
     @property
     def series_queue_count_map(self):


### PR DESCRIPTION
Big ol' refactor to fetch packages which have failed to build in a packageset

To find out which, look for the log "build not successful".

It was interminably slow otherwise, so this refactor adds a thread pool to access LP concurrently. There will be per-thread caches now. Probably do expect some bugs here.