### PR TITLE
Move thread-local LP instances to consumers

### DIFF
--- a/src/prometheus_launchpad_exporter/launchpad.py
+++ b/src/prometheus_launchpad_exporter/launchpad.py
@@ -142,14 +142,3 @@ class LP:
             self.cache_dir,
             version="devel",
         )
-
-    @classmethod
-    def get_lp(cls, local, log):
-        """If this TLS has a launchpad instance, return it, otherwise create a
-        new one"""
-        if not hasattr(local, "lp"):
-            log.debug("creating new LP instance")
-            local.lp = cls(log)
-        else:
-            log.debug("reusing existing LP instance")
-        return local.lp


### PR DESCRIPTION
There was a crazy memory leak that never seemed to end. Instead of trying to find the top of it, this fixes it. Not exactly sure why but we were churning Launchpad instances like mad and they weren't being collected by the GC. Moving the handling of this out of the Launchpad class to the consumers of that class fixes that, memory usage is stable and low now.