### PR TITLE
logging: Output the source name as 'source_name'

### DIFF
--- a/src/prometheus_launchpad_exporter/ubuntu.py
+++ b/src/prometheus_launchpad_exporter/ubuntu.py
@@ -197,7 +197,7 @@ class UbuntuMetrics:
                     source, source_map.get(source)
                 )
                 if sp is None:
-                    log = log.bind(source=source)
+                    log = log.bind(source_name=source)
                     log.debug("creating source package")
                     sp = SourcePackage(log, source, series_name)
                 source_map[source] = sp


### PR DESCRIPTION
In this spot we were using 'source' which is not consistent